### PR TITLE
Added ACF4 support, CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 === Advanced Custom Fields: Autocomplete Field ===
 
-Contributors: Brian S. Reed
+Contributors: Brian S. Reed, Max Lyuchin
 Requires at least: 3.5
 Tested up to: 3.8.1
 Stable tag: trunk
@@ -17,6 +17,7 @@ This is a simple field that looks up values previously entered for this field. T
 
 This ACF field type is compatible with:
 * ACF 5
+* ACF 4
 
 == Installation ==
 

--- a/acf-autocomplete-v4.php
+++ b/acf-autocomplete-v4.php
@@ -1,0 +1,82 @@
+<?php
+
+class acf_field_autocomplete extends acf_field {
+
+	// vars
+	var $settings, // will hold info such as dir / path
+		$defaults; // will hold default field options
+
+
+	function __construct()
+	{
+
+		// vars
+		$this->name = 'autocomplete';
+		$this->label = __('Autocomplete');
+		$this->category = __("Basic",'acf'); // Basic, Content, Choice, etc
+		$this->defaults = array();
+		
+		// do not delete!
+    	parent::__construct();
+    	
+ 		add_action( 'wp_ajax_autocomplete_ajax', array( $this, 'autocomplete_ajax_callback' ) );
+   	
+	}
+
+
+	public function autocomplete_ajax_callback() {
+		
+		global $wpdb;
+		
+		$results = array();
+
+		$results = $wpdb->get_col( $wpdb->prepare( "
+	        SELECT DISTINCT meta_value FROM {$wpdb->postmeta}
+	        WHERE meta_key = '%s'
+	        AND meta_value LIKE %s
+			", $_REQUEST['field_key'], '%'.$_REQUEST['request'].'%' ) );
+
+		echo json_encode($results);
+
+		wp_die(); 
+		
+	}
+	
+	
+	function create_field( $field )
+	{
+
+		?>
+		<input type="text" name="<?php echo esc_attr($field['name']) ?>" value="<?php echo esc_attr($field['value']) ?>" />
+		<?php
+
+	}
+	
+	
+	function input_admin_enqueue_scripts()
+	{
+		
+		$dir = plugin_dir_url( __FILE__ );
+		
+		wp_register_script( 'acf-input-autocomplete', "{$dir}js/input.js", array( "jquery-ui-autocomplete" ) );
+		wp_enqueue_script('acf-input-autocomplete');		
+
+		wp_register_style( 'acf-input-autocomplete', "{$dir}css/input.css", array('acf-input') ); 
+		wp_enqueue_style('acf-input-autocomplete');
+			
+	}
+	
+
+	function update_value( $value, $post_id, $field )
+	{
+		// Trim to remove duplicity
+		return trim($value);
+	}
+		
+}
+
+
+// create field
+new acf_field_autocomplete();
+
+?>

--- a/acf-field-type-autocomplete.php
+++ b/acf-field-type-autocomplete.php
@@ -2,15 +2,17 @@
 
 /*
 Plugin Name: Advanced Custom Fields: Autocomplete
-Plugin URI: http://iambrian.com/#/acf-autocomplete
+Plugin URI: https://github.com/cadic/Advanced-Custom-Fields-Autocomplete
 Description: Simple field that looks up values previously entered for this field.
 Version: 1.0.0
-Author: Brian S. Reed
+Author: Brian S. Reed, Max Lyuchin
 Author URI: http://iambrian.com
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 */
 
+
+// Load ACF5
 load_plugin_textdomain( 'acf-autocomplete', false, dirname( plugin_basename(__FILE__) ) . '/lang/' ); 
 
 function include_field_types_autocomplete( $version ) {
@@ -21,5 +23,13 @@ function include_field_types_autocomplete( $version ) {
 
 add_action('acf/include_field_types', 'include_field_types_autocomplete');	
 
+// Load ACF4
+function register_fields_autocomplete() {
 	
+	include_once('acf-autocomplete-v4.php');
+	
+}
+
+add_action('acf/register_fields', 'register_fields_autocomplete');
+
 ?>

--- a/css/input.css
+++ b/css/input.css
@@ -1,0 +1,2 @@
+ul.ui-autocomplete li { cursor: pointer; }
+ul.ui-autocomplete li:hover { background: #ccc; }

--- a/js/input.js
+++ b/js/input.js
@@ -1,2 +1,64 @@
-(function($){function initialize_field($el){$(':text:visible',$el).autocomplete({source:function(request,response){if(!request.term.trim().length)response([]);$.getJSON(ajaxurl,{'action':'autocomplete_ajax','field_key':$el.data('key'),'request':request.term.trim()},function(data){response(data);});}});}
-if(typeof acf.add_action!=='undefined'){acf.add_action('ready append',function($el){acf.get_fields({type:'autocomplete'},$el).each(function(){initialize_field($(this));});});}else{$(document).on('acf/setup_fields',function(e,postbox){$(postbox).find('.field[data-field_type="autocomplete"]').each(function(){initialize_field($(this));});});}})(jQuery);
+(function($){
+	
+	
+	function initialize_field( $el ) {
+	
+		$(':text:visible',$el).autocomplete({
+			source: function( request, response  ){
+				
+				if(!request.term.trim().length)
+					response( [] );
+				
+				$.getJSON( ajaxurl, { 
+						'action' : 'autocomplete_ajax',
+						'field_key' : $el.data('field_name'),
+						'request' : request.term.trim()
+					}, function( data ){
+					
+					response( data );
+					
+				});
+			}
+		});
+	}
+	
+	if( typeof acf.add_action !== 'undefined' ) {
+	
+		/*
+		*  ready append (ACF5)
+		*/
+		
+		acf.add_action('ready append', function( $el ){
+			
+			// search $el for fields of type 'autocomplete'
+			acf.get_fields({ type : 'autocomplete'}, $el).each(function(){
+				
+				initialize_field( $(this) );
+				
+			});
+			
+		});
+		
+		
+	} else {
+		
+		
+		/*
+		*  acf/setup_fields (ACF4)
+		*/
+		
+		$(document).on('acf/setup_fields', function(e, postbox){
+			
+			$(postbox).find('.field[data-field_type="autocomplete"]').each(function(){
+				
+				initialize_field( $(this) );
+				
+			});
+		
+		});
+	
+	
+	}
+
+
+})(jQuery);


### PR DESCRIPTION
Hi Brian!

I have made ACF4 support for your plugin.

The only thing I doubt will be working with ACF5 is in js/input.js line 14. I've changed it to

```
'field_key' : $el.data('field_name'),
```

It works only this way on ACF4, I dont have ACF5 to check it.
