### PR TITLE
Support for ACF PRO 5

### DIFF
--- a/js/input.js
+++ b/js/input.js
@@ -9,9 +9,13 @@
 				if(!request.term.trim().length)
 					response( [] );
 				
+				if (!(key = $el.data('field_name'))) {
+					key = $el.data('key');
+				}
+				
 				$.getJSON( ajaxurl, { 
 						'action' : 'autocomplete_ajax',
-						'field_key' : $el.data('field_name'),
+						'field_key' : key,
 						'request' : request.term.trim()
 					}, function( data ){
 					


### PR DESCRIPTION
Not sure when this change was introduced, but in the most recent versions of ACF PRO 5 the data attribute that stores the field key is “data-key”, not “data-field_name” which is not set anywhere.

This simply checks “data-key” if “data-field_name” is empty.
