### PR TITLE
Add support to custom WP actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 === Advanced Custom Fields: Autocomplete Field ===
 
-Contributors: Brian S. Reed, Max Lyuchin
+Contributors: Brian S. Reed, Max Lyuchin, Tiago Neto
 Requires at least: 3.5
 Tested up to: 3.8.1
 Stable tag: trunk
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Simple field that looks up values previously entered for this field.
+Simple field that looks up values previously entered for this field. Or you can add a custom WP action to handle your custom autocomplete suggestions.
 
 == Description ==
 
 This is a simple field that looks up values previously entered for this field. This plugin is great for posts that will have a common set of values for the same field but where taxonomy isn't applicable. Plugin uses WordPress core's jQuery UI Autocomplete.
+
+With minimum knowlegde about WP Actions you can also create a custom function to handle the autocomplete the way you need.
 
 = Compatibility =
 
@@ -25,6 +27,29 @@ This ACF field type is compatible with:
 2. Activate the Advanced Custom Fields: Autocomplete plugin via the plugins admin page
 3. Create a new field via ACF and select the Autocomplete type
 4. Please refer to the description for more info regarding the field type settings
+
+== Custom WP Action ==
+
+```
+    public function custom_ajax_callback() {
+
+        global $wpdb;
+
+        $results = array();
+
+        // $_REQUEST['field_key'] => Field name
+        // $_REQUEST['request'] => Text being searched
+
+        // {Your custom code}
+
+        echo json_encode($results);
+
+        wp_die();
+
+    }
+
+    add_action( 'wp_ajax_custom_ajax_callback', array( $this, 'custom_ajax_callback' ) );
+```
 
 == Changelog ==
 

--- a/acf-autocomplete-v4.php
+++ b/acf-autocomplete-v4.php
@@ -15,19 +15,19 @@ class acf_field_autocomplete extends acf_field {
 		$this->label = __('Autocomplete');
 		$this->category = __("Basic",'acf'); // Basic, Content, Choice, etc
 		$this->defaults = array();
-		
+
 		// do not delete!
     	parent::__construct();
-    	
+
  		add_action( 'wp_ajax_autocomplete_ajax', array( $this, 'autocomplete_ajax_callback' ) );
-   	
+
 	}
 
 
 	public function autocomplete_ajax_callback() {
-		
+
 		global $wpdb;
-		
+
 		$results = array();
 
 		$results = $wpdb->get_col( $wpdb->prepare( "
@@ -38,41 +38,74 @@ class acf_field_autocomplete extends acf_field {
 
 		echo json_encode($results);
 
-		wp_die(); 
-		
+		wp_die();
+
 	}
-	
-	
+
+    function create_options( $field )
+    	{
+    		// defaults?
+    		/*
+    		$field = array_merge($this->defaults, $field);
+    		*/
+
+    		// key is needed in the field names to correctly save the data
+    		$key = $field['name'];
+
+
+    		// Create Field Options HTML
+    		?>
+    <tr class="field_option field_option_<?php echo $this->name; ?>">
+    	<td class="label">
+    		<label><?php _e("WP Action",'acf'); ?></label>
+    		<p class="description"><?php _e("WP Action that will handle and deliver the autocomplete suggestions",'acf'); ?></p>
+    	</td>
+    	<td>
+    		<?php
+
+    		do_action('acf/create_field', array(
+    			'type'		=>	'text',
+    			'name'		=>	'fields['.$key.'][wp_action]',
+    			'value'		=>	$field['wp_action']
+    		));
+
+    		?>
+    	</td>
+    </tr>
+    		<?php
+
+    	}
+
 	function create_field( $field )
 	{
 
 		?>
-		<input type="text" name="<?php echo esc_attr($field['name']) ?>" value="<?php echo esc_attr($field['value']) ?>" />
+		<input type="text" name="<?php echo esc_attr($field['name']) ?>" value="<?php echo esc_attr($field['value']) ?>" data-action="<?php echo esc_attr($field['wp_action']) ?>" />
 		<?php
 
 	}
-	
-	
+
+
 	function input_admin_enqueue_scripts()
 	{
-		
-		$dir = plugin_dir_url( __FILE__ );
-		
-		wp_register_script( 'acf-input-autocomplete', "{$dir}js/input.js", array( "jquery-ui-autocomplete" ) );
-		wp_enqueue_script('acf-input-autocomplete');		
 
-		wp_register_style( 'acf-input-autocomplete', "{$dir}css/input.css", array('acf-input') ); 
+		$dir = plugin_dir_url( __FILE__ );
+
+		wp_register_script( 'acf-input-autocomplete', "{$dir}js/input.js", array( "jquery-ui-autocomplete" ) );
+		wp_enqueue_script('acf-input-autocomplete');
+
+		wp_register_style( 'acf-input-autocomplete', "{$dir}css/input.css", array('acf-input') );
 		wp_enqueue_style('acf-input-autocomplete');
-			
+
 	}
-	
+
 
 	function update_value( $value, $post_id, $field )
 	{
 		// Trim to remove duplicity
 		return trim($value);
 	}
-		
+
 }
 
 

--- a/acf-autocomplete.php
+++ b/acf-autocomplete.php
@@ -1,52 +1,52 @@
 <?php
 
 class acf_field_autocomplete extends acf_field {
-	
+
 	function __construct() {
-		
+
 		$this->name = 'autocomplete';
-		
+
 		$this->label = __('Autocomplete', 'acf-autocomplete');
-		
+
 		$this->category = 'basic';
-	
+
 		$this->defaults = array(
 			'font_size'	=> 14,
 		);
-		
+
 		$this->l10n = array(
 			'error'	=> __('Error! Please enter a higher value', 'acf-autocomplete'),
 		);
-		
+
 		parent::__construct();
-    	
+
 		add_action( 'wp_ajax_autocomplete_ajax', array( $this, 'autocomplete_ajax_callback' ) );
-    	
+
 	}
-	
+
 	public function autocomplete_ajax_callback() {
-		
+
 		global $wpdb;
-		
+
 		$results = array();
-		
+
         //$results = array( 'post' => $_POST, 'get' => $_GET );
-        
+
         $results = $wpdb->get_col( $wpdb->prepare( "
          SELECT DISTINCT postmeta2.meta_value FROM $wpdb->postmeta as postmeta1, $wpdb->postmeta as postmeta2 WHERE postmeta1.meta_value = '%s' AND postmeta1.meta_key = CONCAT( '_', postmeta2.meta_key ) AND postmeta2.meta_value LIKE %s",
          $_REQUEST['field_key'],
          '%' . $_REQUEST['request'] . '%'
          ) );
-                
+
 		echo json_encode($results);
 
 
-		wp_die(); 
-		
+		wp_die();
+
 	}
-	
+
 	function render_field_settings( $field ) {
-		
+
 		acf_render_field_setting( $field, array(
 			'label'			=> __('Font Size','acf-autocomplete'),
 			'instructions'	=> __('Customise the input font size','acf-autocomplete'),
@@ -55,24 +55,31 @@ class acf_field_autocomplete extends acf_field {
 			'prepend'		=> 'px',
 		));
 
+        acf_render_field_setting( $field, array(
+			'label'			=> __('WP Action','acf-autocomplete'),
+			'instructions'	=> __('WP Action that will handle and deliver the autocomplete suggestions','acf-autocomplete'),
+			'type'			=> 'text',
+			'name'			=> 'wp_action',
+		));
+
 	}
-	
+
 	function render_field( $field ) {
-		
+
 		?>
-		<input type="text" name="<?php echo esc_attr($field['name']) ?>" value="<?php echo esc_attr($field['value']) ?>" style="font-size:<?php echo $field['font_size'] ?>px;" />
+		<input type="text" name="<?php echo esc_attr($field['name']) ?>" value="<?php echo esc_attr($field['value']) ?>" style="font-size:<?php echo $field['font_size'] ?>px;" data-action="<?php echo esc_attr($field['wp_action']) ?>" />
 		<?php
 	}
-	
+
 	function input_admin_enqueue_scripts() {
-		
+
 		$dir = plugin_dir_url( __FILE__ );
-		
+
 		wp_register_script( 'acf-input-autocomplete', "{$dir}js/input.js", array( "jquery-ui-autocomplete" ) );
 		wp_enqueue_script('acf-input-autocomplete');
-		
+
 	}
-	
+
 }
 
 new acf_field_autocomplete();

--- a/acf-field-type-autocomplete.php
+++ b/acf-field-type-autocomplete.php
@@ -5,7 +5,7 @@ Plugin Name: Advanced Custom Fields: Autocomplete
 Plugin URI: https://github.com/iambriansreed/Advanced-Custom-Fields-Autocomplete
 Description: Simple field that looks up values previously entered for this field.
 Version: 1.0.0
-Author: Brian S. Reed, Max Lyuchin
+Author: Brian S. Reed, Max Lyuchin, Tiago Neto
 Author URI: http://iambrian.com
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -13,21 +13,21 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 
 // Load ACF5
-load_plugin_textdomain( 'acf-autocomplete', false, dirname( plugin_basename(__FILE__) ) . '/lang/' ); 
+load_plugin_textdomain( 'acf-autocomplete', false, dirname( plugin_basename(__FILE__) ) . '/lang/' );
 
 function include_field_types_autocomplete( $version ) {
-	
+
 	include_once('acf-autocomplete.php');
-	
+
 }
 
-add_action('acf/include_field_types', 'include_field_types_autocomplete');	
+add_action('acf/include_field_types', 'include_field_types_autocomplete');
 
 // Load ACF4
 function register_fields_autocomplete() {
-	
+
 	include_once('acf-autocomplete-v4.php');
-	
+
 }
 
 add_action('acf/register_fields', 'register_fields_autocomplete');

--- a/js/input.js
+++ b/js/input.js
@@ -1,63 +1,63 @@
 (function($){
-	
-	
+
+
 	function initialize_field( $el ) {
-	
+
 		$(':text:visible',$el).autocomplete({
 			source: function( request, response  ){
-				
+
 				if(!request.term.trim().length)
 					response( [] );
-				
-				$.getJSON( ajaxurl, { 
+
+				$.getJSON( ajaxurl, {
 						'action' : 'autocomplete_ajax',
 						'field_key' : $el.data('field_name'),
 						'request' : request.term.trim()
 					}, function( data ){
-					
+
 					response( data );
-					
+
 				});
 			}
 		});
 	}
-	
+
 	if( typeof acf.add_action !== 'undefined' ) {
-	
+
 		/*
 		*  ready append (ACF5)
 		*/
-		
+
 		acf.add_action('ready append', function( $el ){
-			
+
 			// search $el for fields of type 'autocomplete'
 			acf.get_fields({ type : 'autocomplete'}, $el).each(function(){
-				
+
 				initialize_field( $(this) );
-				
+
 			});
-			
+
 		});
-		
-		
+
+
 	} else {
-		
-		
+
+
 		/*
 		*  acf/setup_fields (ACF4)
 		*/
-		
+
 		$(document).on('acf/setup_fields', function(e, postbox){
-			
+
 			$(postbox).find('.field[data-field_type="autocomplete"]').each(function(){
-				
+
 				initialize_field( $(this) );
-				
+
 			});
-		
+
 		});
-	
-	
+
+
 	}
 
 


### PR DESCRIPTION
This way the dev/user could handle the autocomplete the way it needs.

I've tested only with ACF4 which is the version I'm working on.